### PR TITLE
GUI エラーメッセージの文字化けの修正

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -10,6 +10,7 @@ exit /b
 
 :build
     msbuild .\cryptopp\cryptlib.vcxproj /t:build /p:Configuration=Release;Platform="x64" || exit /b !ERRORLEVEL!
+    chcp 65001
     msbuild .\shalo-archiver.sln /t:build /p:Configuration=Release || exit /b !ERRORLEVEL!
     cd shaloa-gui-frontend
     call npm ci || cd .. && exit /b !ERRORLEVEL!

--- a/build.bat
+++ b/build.bat
@@ -1,11 +1,13 @@
 @echo off
 @setlocal
 
+chcp 65001 > NUL
+
 call :build || call :error
 exit /b
 
 :error
-echo Build failed (Exit code: %ERRORLEVEL%)
+    echo Build failed (Exit code: %ERRORLEVEL%)
 exit /b
 
 :build

--- a/build.bat
+++ b/build.bat
@@ -1,8 +1,6 @@
 @echo off
 @setlocal
 
-chcp 65001
-
 call :build || call :error
 exit /b
 

--- a/build.bat
+++ b/build.bat
@@ -1,7 +1,7 @@
 @echo off
 @setlocal
 
-chcp 65001 > NUL
+chcp 65001
 
 call :build || call :error
 exit /b

--- a/shaloa/shaloa.cpp
+++ b/shaloa/shaloa.cpp
@@ -154,7 +154,7 @@ int _shaloa_get_last_error_detail(T *buf, size_t buflen, std::basic_string<T> &m
 }
 
 int shaloaGetLastErrorDetailW(wchar_t *buf, size_t buflen) {
-    auto message = convert_multibyte_to_wide(last_error_message, CP_ACP);
+    auto message = convert_multibyte_to_wide(last_error_message, CP_UTF8);
     return _shaloa_get_last_error_detail(buf, buflen, message);
 }
 

--- a/shaloa/shaloa.cpp
+++ b/shaloa/shaloa.cpp
@@ -154,7 +154,7 @@ int _shaloa_get_last_error_detail(T *buf, size_t buflen, std::basic_string<T> &m
 }
 
 int shaloaGetLastErrorDetailW(wchar_t *buf, size_t buflen) {
-    auto message = convert_multibyte_to_wide(last_error_message, CP_UTF8);
+    auto message = convert_multibyte_to_wide(last_error_message, 932);
     return _shaloa_get_last_error_detail(buf, buflen, message);
 }
 

--- a/shaloa/shaloa.vcxproj
+++ b/shaloa/shaloa.vcxproj
@@ -128,7 +128,7 @@
       <PrecompiledHeaderFile/>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalIncludeDirectories>$(BOOSTROOT);$(SolutionDir)\cryptopp;$(SolutionDir)\cryptopp-pem</AdditionalIncludeDirectories>
-      <AdditionalOptions>/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/source-charset:utf-8 %/execution-charset:.932 (AdditionalOptions)</AdditionalOptions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
@@ -151,7 +151,7 @@
       <PrecompiledHeaderFile/>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalIncludeDirectories>$(BOOSTROOT);$(SolutionDir)\cryptopp;$(SolutionDir)\cryptopp-pem</AdditionalIncludeDirectories>
-      <AdditionalOptions>/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/source-charset:utf-8 /execution-charset:.932 %(AdditionalOptions)</AdditionalOptions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/shaloa/shaloa.vcxproj
+++ b/shaloa/shaloa.vcxproj
@@ -128,6 +128,7 @@
       <PrecompiledHeaderFile/>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalIncludeDirectories>$(BOOSTROOT);$(SolutionDir)\cryptopp;$(SolutionDir)\cryptopp-pem</AdditionalIncludeDirectories>
+      <AdditionalOptions>/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
@@ -150,6 +151,7 @@
       <PrecompiledHeaderFile/>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalIncludeDirectories>$(BOOSTROOT);$(SolutionDir)\cryptopp;$(SolutionDir)\cryptopp-pem</AdditionalIncludeDirectories>
+      <AdditionalOptions>/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/shaloa/shaloa.vcxproj
+++ b/shaloa/shaloa.vcxproj
@@ -128,7 +128,7 @@
       <PrecompiledHeaderFile/>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalIncludeDirectories>$(BOOSTROOT);$(SolutionDir)\cryptopp;$(SolutionDir)\cryptopp-pem</AdditionalIncludeDirectories>
-      <AdditionalOptions>/source-charset:utf-8 %/execution-charset:.932 (AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/source-charset:utf-8 /execution-charset:.932 %(AdditionalOptions)</AdditionalOptions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>


### PR DESCRIPTION
Fixes #4.

GitHub Actions によりビルドされた GUI 版のバイナリで、エラーメッセージが文字化けして正しく表示されない問題を修正します。

主な修正点：
- `shaloa.dll` のバイナリ内に埋め込まれるメッセージの文字コードを、明示的に CP932 に指定した。
- エラーメッセージをワイド文字列に変換する処理について、上記の変更に対応させた。
