### PR TITLE
ライセンスリストの入手先を npm の URL に変更

### DIFF
--- a/shaloa-gui-frontend/generate-license.js
+++ b/shaloa-gui-frontend/generate-license.js
@@ -67,7 +67,7 @@ checker.init(
         : lic.licenseText;
       text += "\n\n\n\n";
 
-      const url = lic.repository || `https://www.npmjs.com/package/${lic.name}`;
+      const url = `https://www.npmjs.com/package/${lic.name}`;
       csvText += `${lic.name},${lic.version},${url},${lic.licenses},\n`;
 
       if (


### PR DESCRIPTION
修正点
- ライセンスリストの入手先を `https://www.npmjs.com/package/[パッケージ名]` に変更